### PR TITLE
feat: stop estimating gas in tests [APE-1032]

### DIFF
--- a/ape_polygon/ecosystem.py
+++ b/ape_polygon/ecosystem.py
@@ -3,6 +3,7 @@ from typing import Optional
 from ape.api.config import PluginConfig
 from ape.api.networks import LOCAL_NETWORK_NAME
 from ape_ethereum.ecosystem import Ethereum, NetworkConfig
+from ape.utils import DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT
 
 NETWORKS = {
     # chain_id, network_id
@@ -19,9 +20,13 @@ def _create_network_config(
     )
 
 
-def _create_local_config(default_provider: Optional[str] = None) -> NetworkConfig:
+def _create_local_config(default_provider: Optional[str] = None, **kwargs) -> NetworkConfig:
     return _create_network_config(
-        required_confirmations=0, block_time=0, default_provider=default_provider
+        required_confirmations=0,
+        default_provider=default_provider,
+        transaction_acceptance_timeout=DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT,
+        gas_limit="max",
+        **kwargs,
     )
 
 

--- a/ape_polygon/ecosystem.py
+++ b/ape_polygon/ecosystem.py
@@ -2,8 +2,8 @@ from typing import cast
 
 from ape.api.config import PluginConfig
 from ape.api.networks import LOCAL_NETWORK_NAME
-from ape_ethereum.ecosystem import Ethereum, NetworkConfig
 from ape.utils import DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT
+from ape_ethereum.ecosystem import Ethereum, NetworkConfig
 
 NETWORKS = {
     # chain_id, network_id

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -1,0 +1,14 @@
+import pytest
+from ape_ethereum.transactions import TransactionType
+
+
+def test_gas_limit(networks):
+    arbitrum = networks.arbitrum
+    assert arbitrum.config.local.gas_limit == "max"
+
+
+@pytest.mark.parametrize("type", (0, "0x0"))
+def test_create_transaction(networks, type):
+    polygon = networks.polygon
+    txn = polygon.create_transaction(type=type)
+    assert txn.type == TransactionType.STATIC.value

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -7,11 +7,3 @@ def test_create_transaction(networks, type):
     polygon = networks.polygon
     txn = polygon.create_transaction(type=type)
     assert txn.type == TransactionType.STATIC.value
-
-
-@pytest.mark.parametrize("type", (0, "0x0"))
-def test_create_transaction(polygon, type):
-    with polygon.local.use_provider("test"):
-        txn = polygon.create_transaction(type=type)
-        assert txn.type == TransactionType.STATIC.value
-

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -3,7 +3,7 @@ from ape_ethereum.transactions import TransactionType
 
 
 @pytest.mark.parametrize("type", (0, "0x0"))
-def test_create_transaction(networks, type):
-    polygon = networks.polygon
-    txn = polygon.create_transaction(type=type)
-    assert txn.type == TransactionType.STATIC.value
+def test_create_transaction(polygon, type):
+    with polygon.local.use_provider("test"):
+        txn = polygon.create_transaction(type=type)
+        assert txn.type == TransactionType.STATIC.value


### PR DESCRIPTION
### What I did

Follow changes from `ape-ethereum` and stop estimating gas in tests

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
