### PR TITLE
fix: use `MATIC` as token symbol [APE-1229]

### DIFF
--- a/ape_polygon/ecosystem.py
+++ b/ape_polygon/ecosystem.py
@@ -40,6 +40,8 @@ class PolygonConfig(PluginConfig):
 
 
 class Polygon(Ethereum):
+    fee_token_symbol: str = "MATIC"
+
     @property
     def config(self) -> PolygonConfig:  # type: ignore[override]
         return cast(PolygonConfig, self.config_manager.get_config("polygon"))


### PR DESCRIPTION
### What I did

Also, is 18 (the default) still the decimals?

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
