### PR TITLE
fix: issue where mistakenly said `EthTester` can handle fork networks [APE-1392]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
     -   id: check-yaml
 
@@ -10,24 +10,24 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.9.1
     hooks:
       - id: black
         name: black
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.5.1
     hooks:
     -   id: mypy
         additional_dependencies: [types-setuptools, pydantic]
 
 -   repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.14
+    rev: 0.7.17
     hooks:
     -   id: mdformat
         additional_dependencies: [mdformat-gfm, mdformat-frontmatter]

--- a/ape_polygon/__init__.py
+++ b/ape_polygon/__init__.py
@@ -31,6 +31,5 @@ def networks():
 def providers():
     for network_name in NETWORKS:
         yield "polygon", network_name, GethProvider
-        yield "polygon", f"{network_name}-fork", LocalProvider
 
     yield "polygon", LOCAL_NETWORK_NAME, LocalProvider

--- a/ape_polygon/ecosystem.py
+++ b/ape_polygon/ecosystem.py
@@ -22,10 +22,11 @@ def _create_network_config(
 
 def _create_local_config(**kwargs) -> NetworkConfig:
     return _create_network_config(
-        required_confirmations=0,
-        default_provider="test",
-        transaction_acceptance_timeout=DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT,
+        block_time=0,
+        default_provider=kwargs.pop("default_provider", None),
         gas_limit="max",
+        required_confirmations=0,
+        transaction_acceptance_timeout=DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT,
         **kwargs,
     )
 
@@ -35,7 +36,7 @@ class PolygonConfig(PluginConfig):
     mainnet_fork: NetworkConfig = _create_local_config()
     mumbai: NetworkConfig = _create_network_config()
     mumbai_fork: NetworkConfig = _create_local_config()
-    local: NetworkConfig = _create_local_config()
+    local: NetworkConfig = _create_local_config(default_provider="test")
     default_network: str = LOCAL_NETWORK_NAME
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0"]
+requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0,<8"]
 
 [tool.mypy]
 exclude = "build/"

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,12 @@ extras_require = {
         "hypothesis>=6.2.0,<7",  # Strategy-based fuzzer
     ],
     "lint": [
-        "black>=23.3.0,<24",  # Auto-formatter and linter
-        "mypy>=0.991,<1",  # Static type analyzer
+        "black>=23.9.1,<24",  # Auto-formatter and linter
+        "mypy>=1.5.1,<2",  # Static type analyzer
         "types-setuptools",  # Needed due to mypy typeshed
-        "flake8>=6.0.0,<7",  # Style linter
+        "flake8>=6.1.0,<7",  # Style linter
         "isort>=5.10.1,<6",  # Import sorting linter
-        "mdformat>=0.7.16",  # Auto-formatter for markdown
+        "mdformat>=0.7.17",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,5 @@
 import ape
 import pytest
-from ape._cli import cli as ape_cli
-from click.testing import CliRunner
 
 
 @pytest.fixture
@@ -15,15 +13,14 @@ def accounts():
 
 
 @pytest.fixture
-def runner():
-    return CliRunner()
-
-
-@pytest.fixture
-def cli():
-    return ape_cli
-
-
-@pytest.fixture
 def polygon(networks):
     return networks.polygon
+
+
+@pytest.fixture
+def eth_tester_provider():
+    if not ape.networks.active_provider or ape.networks.provider.name != "test":
+        with ape.networks.polygon.local.use_provider("test") as provider:
+            yield provider
+    else:
+        yield ape.networks.provider

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -1,9 +1,37 @@
 import pytest
 from ape_ethereum.transactions import TransactionType
+from ethpm_types.abi import MethodABI
 
 
-@pytest.mark.parametrize("type", (0, "0x0"))
-def test_create_transaction(polygon, type):
-    with polygon.local.use_provider("test"):
-        txn = polygon.create_transaction(type=type)
-        assert txn.type == TransactionType.STATIC.value
+def test_gas_limit(polygon):
+    assert polygon.config.local.gas_limit == "max"
+
+
+# NOTE: None because we want to show the default is DYNAMIC
+@pytest.mark.parametrize("type", (None, 2, "0x2"))
+def test_create_transaction(polygon, type, eth_tester_provider):
+    tx = polygon.create_transaction(type=type)
+    assert tx.type == TransactionType.DYNAMIC.value
+    assert tx.gas_limit == eth_tester_provider.max_gas
+
+
+@pytest.mark.parametrize(
+    "type_",
+    (
+        TransactionType.STATIC.value,
+        TransactionType.DYNAMIC.value,
+    ),
+)
+def test_encode_transaction(type_, polygon, eth_tester_provider):
+    abi = MethodABI.parse_obj(
+        {
+            "type": "function",
+            "name": "fooAndBar",
+            "stateMutability": "nonpayable",
+            "inputs": [],
+            "outputs": [],
+        }
+    )
+    address = "0x274b028b03A250cA03644E6c578D81f019eE1323"
+    actual = polygon.encode_transaction(address, abi, sender=address, type=type_)
+    assert actual.gas_limit == eth_tester_provider.max_gas

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -8,21 +8,21 @@ def test_gas_limit(polygon):
 
 
 # NOTE: None because we want to show the default is DYNAMIC
-@pytest.mark.parametrize("type", (None, 2, "0x2"))
-def test_create_transaction(polygon, type, eth_tester_provider):
-    tx = polygon.create_transaction(type=type)
+@pytest.mark.parametrize("tx_type", (None, 2, "0x2"))
+def test_create_transaction(polygon, tx_type, eth_tester_provider):
+    tx = polygon.create_transaction(type=tx_type)
     assert tx.type == TransactionType.DYNAMIC.value
     assert tx.gas_limit == eth_tester_provider.max_gas
 
 
 @pytest.mark.parametrize(
-    "type_",
+    "tx_type",
     (
         TransactionType.STATIC.value,
         TransactionType.DYNAMIC.value,
     ),
 )
-def test_encode_transaction(type_, polygon, eth_tester_provider):
+def test_encode_transaction(tx_type, polygon, eth_tester_provider):
     abi = MethodABI.parse_obj(
         {
             "type": "function",
@@ -33,5 +33,5 @@ def test_encode_transaction(type_, polygon, eth_tester_provider):
         }
     )
     address = "0x274b028b03A250cA03644E6c578D81f019eE1323"
-    actual = polygon.encode_transaction(address, abi, sender=address, type=type_)
+    actual = polygon.encode_transaction(address, abi, sender=address, type=tx_type)
     assert actual.gas_limit == eth_tester_provider.max_gas

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,3 +1,7 @@
+import pytest
+from ape._cli import cli as ape_cli
+from click.testing import CliRunner
+
 EXPECTED_OUTPUT = """
 polygon
 ├── mainnet
@@ -7,6 +11,16 @@ polygon
 └── local  (default)
     └── test  (default)
 """.strip()
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def cli():
+    return ape_cli
 
 
 def assert_rich_text(actual: str, expected: str):
@@ -30,6 +44,10 @@ def assert_rich_text(actual: str, expected: str):
         assert expected_line in actual_lines
 
 
-def test_networks(runner, cli):
+def test_networks(runner, cli, polygon):
+    # Do this in case local env changed it.
+    polygon.mainnet.set_default_provider("geth")
+    polygon.mumbai.set_default_provider("geth")
+
     result = runner.invoke(cli, ["networks", "list"])
     assert_rich_text(result.output, EXPECTED_OUTPUT)


### PR DESCRIPTION
### What I did

it showed:

```
├── mainnet-fork
│   ├── foundry
│   ├── ganache
│   ├── hardhat
|   └── test (default)
```

even though that is not true.
so i realized someone (prolly me) mistakenly put the fork part in the providers instead of the networks but it was in both

### How I did it

remove it from providers.
basically, copy all the other L2 plugins. this was the only one that was bad.

### How to verify it

```sh
ape networks list --ecosystem polygon
```

all the fork networks should not have `test` as a provider.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
