### PR TITLE
chore: delete mumbai network

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,12 @@ repos:
         name: black
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+    rev: 7.1.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.10.1
     hooks:
     -   id: mypy
         additional_dependencies: [types-setuptools, pydantic]

--- a/ape_polygon/ecosystem.py
+++ b/ape_polygon/ecosystem.py
@@ -10,7 +10,6 @@ from ape_ethereum.ecosystem import (
 NETWORKS = {
     # chain_id, network_id
     "mainnet": (137, 137),
-    "mumbai": (80001, 80001),
     "amoy": (80002, 80002),
 }
 
@@ -18,7 +17,6 @@ NETWORKS = {
 class PolygonConfig(BaseEthereumConfig):
     NETWORKS: ClassVar[Dict[str, Tuple[int, int]]] = NETWORKS
     mainnet: NetworkConfig = create_network_config(block_time=2, required_confirmations=1)
-    mumbai: NetworkConfig = create_network_config(block_time=2, required_confirmations=1)
     amoy: NetworkConfig = create_network_config(block_time=2, required_confirmations=1)
 
 

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,9 @@ extras_require = {
     ],
     "lint": [
         "black>=24.4.2,<25",  # Auto-formatter and linter
-        "mypy>=1.10.0,<2",  # Static type analyzer
+        "mypy>=1.10.1,<2",  # Static type analyzer
         "types-setuptools",  # Needed for mypy type shed
-        "flake8>=7.0.0,<8",  # Style linter
+        "flake8>=7.1.0,<8",  # Style linter
         "flake8-breakpoint>=1.1.0,<2",  # Detect breakpoints left in code
         "flake8-print>=5.0.0,<6",  # Detect print statements left in code
         "isort>=5.13.2,<6",  # Import sorting linter

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,9 +8,7 @@ polygon
 │   └── node  (default)
 ├── local  (default)
 │   └── test  (default)
-├── mainnet
-│   └── node  (default)
-└── mumbai
+└── mainnet
     └── node  (default)
 """.strip()
 
@@ -49,7 +47,6 @@ def assert_rich_text(actual: str, expected: str):
 def test_networks(runner, cli, polygon):
     # Do this in case local env changed it.
     polygon.mainnet.set_default_provider("node")
-    polygon.mumbai.set_default_provider("node")
     polygon.amoy.set_default_provider("node")
 
     result = runner.invoke(cli, ("networks", "list"))


### PR DESCRIPTION
### What I did

Mumbai has been gone since April 8th so it is time to delete this network. Also, some other plugins already have..

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
