### PR TITLE
perf: plugin load time

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
     -   id: check-yaml
 
@@ -10,7 +10,7 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
       - id: black
         name: black
@@ -21,13 +21,13 @@ repos:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
+    rev: v1.13.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-setuptools, pydantic]
 
 -   repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.17
+    rev: 0.7.18
     hooks:
     -   id: mdformat
         additional_dependencies: [mdformat-gfm, mdformat-frontmatter]

--- a/ape_polygon/__init__.py
+++ b/ape_polygon/__init__.py
@@ -1,23 +1,31 @@
 from ape import plugins
-from ape.api.networks import LOCAL_NETWORK_NAME, ForkedNetworkAPI, NetworkAPI, create_network_type
-from ape_node import Node
-from ape_test import LocalProvider
-
-from .ecosystem import NETWORKS, Polygon, PolygonConfig
 
 
 @plugins.register(plugins.Config)
 def config_class():
+    from ape_polygon.ecosystem import PolygonConfig
+
     return PolygonConfig
 
 
 @plugins.register(plugins.EcosystemPlugin)
 def ecosystems():
+    from ape_polygon.ecosystem import Polygon
+
     yield Polygon
 
 
 @plugins.register(plugins.NetworkPlugin)
 def networks():
+    from ape.api.networks import (
+        LOCAL_NETWORK_NAME,
+        ForkedNetworkAPI,
+        NetworkAPI,
+        create_network_type,
+    )
+
+    from ape_polygon.ecosystem import NETWORKS
+
     for network_name, network_params in NETWORKS.items():
         yield "polygon", network_name, create_network_type(*network_params)
         yield "polygon", f"{network_name}-fork", ForkedNetworkAPI
@@ -28,6 +36,12 @@ def networks():
 
 @plugins.register(plugins.ProviderPlugin)
 def providers():
+    from ape.api.networks import LOCAL_NETWORK_NAME
+    from ape_node import Node
+    from ape_test import LocalProvider
+
+    from ape_polygon.ecosystem import NETWORKS
+
     for network_name in NETWORKS:
         yield "polygon", network_name, Node
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,9 @@
 [flake8]
 max-line-length = 100
+ignore = E704,W503,PYD002,TC003,TC006
 exclude =
 	venv*
 	.eggs
 	docs
 	build
+type-checking-pydantic-enabled = True

--- a/setup.py
+++ b/setup.py
@@ -10,14 +10,14 @@ extras_require = {
         "hypothesis>=6.2.0,<7",  # Strategy-based fuzzer
     ],
     "lint": [
-        "black>=24.8.0,<25",  # Auto-formatter and linter
-        "mypy>=1.11.2,<2",  # Static type analyzer
+        "black>=24.10.0,<25",  # Auto-formatter and linter
+        "mypy>=1.13.0,<2",  # Static type analyzer
         "types-setuptools",  # Needed for mypy type shed
         "flake8>=7.1.1,<8",  # Style linter
         "flake8-breakpoint>=1.1.0,<2",  # Detect breakpoints left in code
         "flake8-print>=5.0.0,<6",  # Detect print statements left in code
         "isort>=5.13.2,<6",  # Import sorting linter
-        "mdformat>=0.7.17",  # Auto-formatter for markdown
+        "mdformat>=0.7.18",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
         "mdformat-pyproject>=0.0.1",  # Allows configuring in pyproject.toml


### PR DESCRIPTION
### What I did

before:

```
CPU times: user 1.85 s, sys: 184 ms, total: 2.03 s
Wall time: 2.05 s
```

after:

```
In [1]: %time import ape_polygon
CPU times: user 7.99 ms, sys: 3.13 ms, total: 11.1 ms
Wall time: 10.1 ms
```

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
